### PR TITLE
add pillar example on how to enable rabbitmq plugins

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -17,9 +17,7 @@ rabbitmq:
     user1:
       - password: password
       - force: True
-      - tags:
-          - monitoring
-          - user
+      - tags: monitoring, user
       - perms:
         - '/':
           - '.*'


### PR DESCRIPTION
add pillar example on how to enable rabbitmq plugins
