### PR TITLE
create vhosts, then users, then add users to vhosts

### DIFF
--- a/rabbitmq/config.sls
+++ b/rabbitmq/config.sls
@@ -21,12 +21,12 @@
       - service: rabbitmq-server
 {% endfor %}
 
+# need to create vhosts, then users, then add users to vhosts
+
 {% for name, policy in salt["pillar.get"]("rabbitmq:vhost", {}).iteritems() %}
-{{ name }}:
+rabbitmq_vhost_{{ name }}:
   rabbitmq_vhost.present:
-    {% for value in policy %}
-    - {{ value }}
-    {% endfor %}
+    - name: {{ name }}
     - require:
       - service: rabbitmq-server
 {% endfor %}


### PR DESCRIPTION
I noticed that the existing recipe gets in a loop because it tries to create vhosts and add users, before the user is created (or maybe it's create users and add to vhosts, before vhost is created).

Anyway, I did a quick fix to get it working, then used the following sort of pillar data. I'm new to Rabbit and Salt, so there's probably better ways of doing this, or I may have misunderstood how to use this formula.

```
rabbitmq:
  vhost:
    graphite:
    /mcollective:

# users: username, password, list of vhosts
{% set users = [
  ('rabmin', 'sekret',
    ['/', 'graphite', '/mcollective']
  ),
  ('collectd', 'sekret',
    ['graphite']
  ),
  ('graphite', 'sekret',
    ['graphite']
  ),
  ('mcollective', 'sekret',
    ['/mcollective']
  ),
] %}

  user:
    {% for user, password, vhosts in users %}
      {{user}}:
      - password: {{password}}
      - force: True
      - runas: root
      {% if user == 'rabmin' %}
      - tags: administrator
      {% endif %}
      - perms:
      {% for vhost in vhosts %}
        - {{vhost}}:
          - '.*'
          - '.*'
          - '.*'
      {% endfor %}
    {% endfor %}
```

mcollective, yes... Current company is migrating Puppet -> Salt :-)
