### PR TITLE
Fix plugin installation

### DIFF
--- a/rabbitmq/config.sls
+++ b/rabbitmq/config.sls
@@ -4,6 +4,7 @@
     {% for value in plugin %}
     - {{ value }}
     {% endfor %}
+    - runas: root
     - require:
       - pkg: rabbitmq-server
       - file: rabbitmq_binary_tool_plugins


### PR DESCRIPTION
According to https://github.com/saltstack/salt/issues/15096 the "runas" parameter appears to be required. 
Without it, the plugin installation fails.