### PR TITLE
Added packagecloud repo to install in CentOS 6

### DIFF
--- a/rabbitmq/latest.sls
+++ b/rabbitmq/latest.sls
@@ -1,8 +1,6 @@
-{% if grains['os_family'] == 'Debian' %}
-
 include:
   - rabbitmq
-
+{% if grains['os_family'] == 'Debian' %}
 rabbitmq_repo:
   pkgrepo.managed:
     - humanname: RabbitMQ Repository
@@ -11,5 +9,16 @@ rabbitmq_repo:
     - key_url: http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
     - require_in:
       - pkg: rabbitmq-server
-
+{% elif grains['os'] == 'CentOS' and grains['osmajorrelease'][0] == '6' %}
+rabbitmq_repo:
+  pkgrepo.managed:
+    - humanname: RabbitMQ Packagecloud Repository
+    - baseurl: https://packagecloud.io/rabbitmq/rabbitmq-server/el/6/$basearch
+    - gpgcheck: 1
+    - enabled: True
+    - gpgkey: https://packagecloud.io/gpg.key
+    - sslverify: 1
+    - sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    - require_in:
+      - pkg: rabbitmq-server
 {% endif %}


### PR DESCRIPTION
Due the version in the official CentOS repository is quite old I've added to the latest.sls state another if statement to create a packagecloud repo file.