### PR TITLE
rabbitmq_vhost state deprecated policy arguments

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,7 +10,7 @@ rabbitmq:
       - definition: '{"ha-mode": "all"}'
   vhost:
     virtual_host:
-      - user: rabbit_user
+      - owner: rabbit_user
       - conf: .*
       - write: .*
       - read: .*


### PR DESCRIPTION
**Related to:** https://github.com/saltstack-formulas/rabbitmq-formula/issues/18

For this formula, you only need to change the pillar, since the vhost permission is retrieved from there. The user is actually replaced by owner, in salt 2015.5.0 (Lithium)

```
[WARNING ] /usr/lib/python2.7/dist-packages/salt/states/rabbitmq_vhost.py:79: DeprecationWarning: The 'user' argument is being deprecated in favor of 'owner', and will be removed in Salt Beryllium. Please update your state files.
```

The message from rabbitmq_vhost.py in the salt repo seems not right, I am not sure how it got through. I tested it and it fails here: 

```
----------
          ID: rabbitmq_vhost_
    Function: rabbitmq_vhost.present
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1563, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/states/rabbitmq_vhost.py", line 84, in present
                  if any(user, owner, conf, write, read):
              TypeError: any() takes exactly one argument (5 given)
```

Replacing user for owner looks like the fix for now. According to the documentation I am not sure how permissions are going to work, given that everything is deprecated (http://docs.saltstack.com/en/latest/ref/states/all/salt.states.rabbitmq_vhost.html)