### PR TITLE
Fix url key for debian package

### DIFF
--- a/rabbitmq/latest.sls
+++ b/rabbitmq/latest.sls
@@ -1,13 +1,13 @@
 include:
   - rabbitmq
-  
+
 {% if grains['os_family'] == 'Debian' %}
 rabbitmq_repo:
   pkgrepo.managed:
     - humanname: RabbitMQ Repository
     - name: deb http://www.rabbitmq.com/debian/ testing main
     - file: /etc/apt/sources.list.d/rabbitmq.list
-    - key_url: http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+    - key_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
     - require_in:
       - pkg: rabbitmq-server
 {% elif grains['os'] == 'CentOS' and grains['osmajorrelease'][0] == '6' %}


### PR DESCRIPTION
As informed at rabbitmq's [site](https://www.rabbitmq.com/install-debian.html#apt), the url that has the key for package validation now is **https://www.rabbitmq.com/rabbitmq-release-signing-key.asc** instead of **http://www.rabbitmq.com/rabbitmq-signing-key-public.asc**.