### PR TITLE
this should fix the case when policy requires vhost to be created first

### DIFF
--- a/rabbitmq/config.sls
+++ b/rabbitmq/config.sls
@@ -12,20 +12,20 @@
       - service: rabbitmq-server
 {% endfor %}
 
+{% for name, vhost in salt["pillar.get"]("rabbitmq:vhost", {}).items() %}
+rabbitmq_vhost_{{ name }}:
+  rabbitmq_vhost.present:
+    - name: {{ vhost }}
+    - require:
+      - service: rabbitmq-server
+{% endfor %}
+
 {% for name, policy in salt["pillar.get"]("rabbitmq:policy", {}).items() %}
 {{ name }}:
   rabbitmq_policy.present:
     {% for value in policy %}
     - {{ value }}
     {% endfor %}
-    - require:
-      - service: rabbitmq-server
-{% endfor %}
-
-{% for name, vhost in salt["pillar.get"]("rabbitmq:vhost", {}).items() %}
-rabbitmq_vhost_{{ name }}:
-  rabbitmq_vhost.present:
-    - name: {{ vhost }}
     - require:
       - service: rabbitmq-server
 {% endfor %}


### PR DESCRIPTION
Hello,

Currently, in this formula, policies are created before vhosts and therefore their creation fails if vhost is required to exist already.

So, I have changed the execution order, vhosts are generated first and then policies.
