### PR TITLE
Fix salt 2019.2 breaking change using yaml filter

### DIFF
--- a/rabbitmq/config.sls
+++ b/rabbitmq/config.sls
@@ -24,7 +24,7 @@ rabbitmq_vhost_{{ name }}:
 {{ name }}:
   rabbitmq_policy.present:
     {% for value in policy %}
-    - {{ value | yaml }}
+    - {{ value | json }}
     {% endfor %}
     - require:
       - service: rabbitmq-server
@@ -35,7 +35,7 @@ rabbitmq_user_{{ name }}:
   rabbitmq_user.present:
     - name: {{ name }}
     {% for value in user %}
-    - {{ value | yaml }}
+    - {{ value | json }}
     {% endfor %}
     - require:
       - service: rabbitmq-server

--- a/rabbitmq/config.sls
+++ b/rabbitmq/config.sls
@@ -24,7 +24,7 @@ rabbitmq_vhost_{{ name }}:
 {{ name }}:
   rabbitmq_policy.present:
     {% for value in policy %}
-    - {{ value }}
+    - {{ value | yaml }}
     {% endfor %}
     - require:
       - service: rabbitmq-server
@@ -35,7 +35,7 @@ rabbitmq_user_{{ name }}:
   rabbitmq_user.present:
     - name: {{ name }}
     {% for value in user %}
-    - {{ value }}
+    - {{ value | yaml }}
     {% endfor %}
     - require:
       - service: rabbitmq-server


### PR DESCRIPTION
With the salt 2019.2.0 (Fluorine) release there has been a [non-backward-compatible change to the yaml renderer](https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer). 

This PR addresses that change by using the yaml filter where necessary. 