### PR TITLE
Ensure guest user is removed by default

### DIFF
--- a/rabbitmq/config.sls
+++ b/rabbitmq/config.sls
@@ -40,3 +40,10 @@ rabbitmq_user_{{ name }}:
     - require:
       - service: rabbitmq-server
 {% endfor %}
+
+{% if "guest" not in salt["pillar.get"]("rabbitmq:user", {}).keys() %}
+rabbitmq_user_guest:
+  rabbitmq_user.absent:
+    - name: guest
+    - runas: root
+{% endif %}


### PR DESCRIPTION
https://www.rabbitmq.com/access-control.html indicates that "It is
advisable to delete the guest user or at least change its password to
reasonably secure generated value that won't be known to the public."

Thus, unless the guest user is defined in pillar data, we remove it to
reduce the risk of having a weak password on this loopback-only user.