### PR TITLE
fix: federation upstream set (ci error)

### DIFF
--- a/rabbitmq/config/parameters/install.sls
+++ b/rabbitmq/config/parameters/install.sls
@@ -18,7 +18,7 @@ rabbitmq-config-parameters-present-{{ name }}-{{ param }}:
                 {%- if p.component == 'federation-upstream' %}
             /usr/sbin/rabbitmqctl --node {{ name }} set_parameter --vhost={{ '/' if 'vhost' not in p else p.vhost }} {{ p.component }} '{{ param }}' '{{ p.definition|json }}'  # noqa 204
                 {%- else %}{# federation-upstream-set for now #}
-            /usr/sbin/rabbitmqctl --node {{ name }} set_parameter --vhost={{ '/' if 'vhost' not in p else p.vhost }} {{ p.component }} '{{ param }}' '[{{ p.definition|json }},]'  # noqa 204
+            /usr/sbin/rabbitmqctl --node {{ name }} set_parameter --vhost={{ '/' if 'vhost' not in p else p.vhost }} {{ p.component }} '{{ param }}' '[{{ p.definition|json }}]'  # noqa 204
                 {%- endif %}
     - runas: rabbitmq
     - onlyif: test -x /usr/sbin/rabbitmqctl


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This fixes 2 errors in the CI vms, and probably in regular use too, regarding federation setup : 

first error : 

```
       ----------
                 ID: rabbitmq-config-parameters-present-rabbit-my-federation-upstream-set
           Function: cmd.run
               Name: /usr/sbin/rabbitmqctl --node rabbit set_parameter --vhost=default_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204
             Result: False
            Comment: Command "/usr/sbin/rabbitmqctl --node rabbit set_parameter --vhost=default_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204" run
            Started: 15:54:19.151211
           Duration: 466.897 ms
            Changes:   
              ----------
              pid:
                  7865
              retcode:
                  69
              stderr:
                  warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
                  Error:
                  Could not parse JSON document: {error,
                                                     {failed_to_decode_json,
                                                         <<"[{\"upstream\": \"my-federation-upstream1\"},]">>}}
              stdout:
                  Setting runtime parameter "my-federation-upstream-set" for component "federation-upstream-set" to "[{"upstream": "my-federation-upstream1"},]" in vhost "default_vhost" ...
```

second error : 

```
       ----------
                 ID: rabbitmq-config-parameters-present-rabbit2-my-federation-upstream-set
           Function: cmd.run
               Name: /usr/sbin/rabbitmqctl --node rabbit2 set_parameter --vhost=rabbit2_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204
             Result: False
            Comment: Command "/usr/sbin/rabbitmqctl --node rabbit2 set_parameter --vhost=rabbit2_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204" run
            Started: 15:54:20.079375
           Duration: 457.14 ms
            Changes:   
              ----------
              pid:
                  7981
              retcode:
                  69
              stderr:
                  warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
                  Error:
                  Could not parse JSON document: {error,
                                                     {failed_to_decode_json,
                                                         <<"[{\"upstream\": \"my-federation-upstream1\"},]">>}}
              stdout:
                  Setting runtime parameter "my-federation-upstream-set" for component "federation-upstream-set" to "[{"upstream": "my-federation-upstream1"},]" in vhost "rabbit2_vhost" ...
```


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


