### PR TITLE
fix: recursive requisite rabbitmqadmin with latest salt builds

### DIFF
--- a/rabbitmq/config/plugins/install.sls
+++ b/rabbitmq/config/plugins/install.sls
@@ -26,20 +26,15 @@ rabbitmq-config-plugins-enabled-{{ name }}-{{ plugin }}:
 
 rabbitmq-config-plugins-{{ name }}-rabbitmqadmin-install:
   cmd.run:
-    - name : curl -k -L http://127.0.0.1:15672/cli/rabbitmqadmin -o /usr/local/sbin/rabbitmqadmin
-    - unless: test -x /usr/local/sbin/rabbitmqadmin
+    {%- set rabbitmqadmin = "/usr/local/sbin/rabbitmqadmin" %}
+    - name: >
+        curl -k -L http://127.0.0.1:15672/cli/rabbitmqadmin -o {{ rabbitmqadmin }}
+        && chown root:{{ rabbitmq.rootgroup }} {{ rabbitmqadmin }}
+        && chmod 755 {{ rabbitmqadmin }}
+    - unless: test -x {{ rabbitmqadmin }}
     - onlyif: /usr/sbin/rabbitmq-plugins --node {{ name }} is_enabled rabbitmq_management
     - require:
       - sls: {{ sls_service_running }}
-  file.managed:
-   - name: /usr/local/sbin/rabbitmqadmin
-   - user: root
-   - force: false
-   - replace: false
-   - group: {{ rabbitmq.rootgroup }}
-   - mode: 755
-   - require:
-     - cmd : rabbitmq-config-plugins-{{ name }}-rabbitmqadmin-install
 
                 {%- endif %}
             {%- endfor %}


### PR DESCRIPTION
(Work In Progress)

See https://github.com/saltstack-formulas/rabbitmq-formula/pull/139 for up to date CI results without any code change.

Eight different OSes fail with : 

```
       ----------
                 ID: rabbitmq-config-plugins-rabbit-rabbitmqadmin-install
           Function: cmd.run
               Name: curl -k -L http://127.0.0.1:15672/cli/rabbitmqadmin -o /usr/local/sbin/rabbitmqadmin
             Result: False
            Comment: Recursive requisite found
            Changes:   
       ----------

```

I think it is caused by a change in Salt's code for detecting recursive requisites.
